### PR TITLE
Use flit to make this extension a package.

### DIFF
--- a/ipython_physics.py
+++ b/ipython_physics.py
@@ -7,6 +7,8 @@ Author: Georg Brandl <georg@python.org>.
 This file has been placed in the public domain.
 """
 
+__version__ = "0.1.0"
+
 import re
 import sys
 from math import pi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["flit_core >=3.2,<4"]
+build-backend = "flit_core.buildapi"
+
+[project]
+name = "ipython_physics"
+authors = [{name = "Georg Brandl", email = "georg@python.org"}]
+readme = "README.md"
+classifiers = ["License :: OSI Approved :: MIT License"]
+dynamic = ["version", "description"]
+
+[project.urls]
+Home = "https://github.com/birkenfeld/ipython-physics"


### PR DESCRIPTION
IPython has deprecated loading extensions from pure files and suggest to make extensions packages.

This was requested on the IPython-dev mailing list. 